### PR TITLE
Destroy fixture after each test

### DIFF
--- a/src/app/02-integrated-tests/components/06-component-w-input-output/user-list/user/user.component.spec.ts
+++ b/src/app/02-integrated-tests/components/06-component-w-input-output/user-list/user/user.component.spec.ts
@@ -58,4 +58,8 @@ describe('UserComponent', () => {
     userEl.triggerEventHandler('click', null);
     expect(selectedUser).toBe(expectedUser);
   });
+  
+  afterEach(() => {
+    fixture.destroy();
+  });
 });


### PR DESCRIPTION
При запуске теста 'should display user name' получаю ошибку "Uncaught TypeError: Cannot read property of undefined thrown". В дебагере я вижу что значение userEl.nativeElement.textContent в точности равно требуемому. Но при выполнении строки №40, я вижу что тест не прошел. На stackOverflow описывается подобная проблема: проблема в том что не очищается значение fixture после каждого теста. После того как сделал уничтожение fixture каждый тест, все заработало.